### PR TITLE
Fix viewport height and disable mobile swipes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>サイバーパンク ロボットランナー</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/script.js
+++ b/script.js
@@ -822,8 +822,13 @@ window.addEventListener('load', () => {
     resizeCanvas(); // Ensure canvas is sized correctly on load
     checkOrientation(); // Check orientation and start game or show message
     // 初回ロード時にinitGameを呼び出すが、checkOrientationがすでに呼んでいるためコメントアウト
-    // initGame(); 
+    // initGame();
 });
+
+// Disable default touchmove scrolling on mobile devices
+document.addEventListener('touchmove', (e) => {
+    e.preventDefault();
+}, { passive: false });
 
 // ゲームの開始
 // ゲームオーバー/ステージクリア時のボタンクリックによってinitGameが呼び出されるようにするため、

--- a/style.css
+++ b/style.css
@@ -18,11 +18,14 @@ body {
     font-family: 'Courier New', monospace;
     background: linear-gradient(135deg, #0a0f23 0%, #1a1a2e 50%, #16213e 100%);
     color: #00ffff;
-    min-height: 100vh;
+    height: 100vh;
+    height: 100dvh; /* モバイルでの正確なビューポート高さ */
     display: flex;
     justify-content: center;
     align-items: center;
     overflow: hidden; /* デフォルトはoverflow: hidden */
+    touch-action: none; /* モバイルスワイプによるスクロール無効化 */
+    overscroll-behavior: none;
 }
 
 .game-container {
@@ -30,10 +33,11 @@ body {
     padding: 20px;
     max-width: 900px;
     width: 100%;
+    height: 100%;
     display: flex; /* 追加: flexboxで子要素を配置 */
     flex-direction: column; /* 追加: 縦方向に並べる */
     align-items: center; /* 追加: 中央揃え */
-    justify-content: center; /* 追加: 中央揃え */
+    justify-content: space-between; /* 追加: 上下にぴったり配置 */
 }
 
 .game-header {


### PR DESCRIPTION
## Summary
- Ensure full-screen layout on mobile by using dynamic viewport height and full-height game container
- Prevent touchmove scrolling and disable mobile swipe interactions

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0241c94e48330bef8e5b8b92035f2